### PR TITLE
デストラクタでのフラグ管理について

### DIFF
--- a/src/UrgBase.cpp
+++ b/src/UrgBase.cpp
@@ -73,7 +73,7 @@ UrgBase::UrgBase(const char* filename, int baudrate, int defaultTimeoutMilliSec)
 
 UrgBase::~UrgBase()
 {
-	if(this->m_Endflag) {
+	if(!this->m_Endflag) {
 		std::cout << "[UrgBase] Stopping Urg Background Job" << std::endl;
 		Stop();
 		std::cout << "[UrgBase] Stopped." << std::endl;


### PR DESCRIPTION
デストラクタにおいて，スレッドを停止するプロセスに入れようとしているのですが，m_Endflagがこの段階ではfalseしか取り得ないため，終了時にこのルーチンに入らずにSegmentation Faultで落ちる用です．
m_EndflagをTrueに変更するのはStop関数の中にありましたので，そもそもここはfalseであることを前提にした実装になるかと思いましたので，そのように修正してみました．
ご確認お願いいたします．
